### PR TITLE
Fix installer failing due to process being mispelled

### DIFF
--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -53,7 +53,7 @@ requireSelenium(function(selenium) {
   selenium.install(config, function(error) {
     if (error) {
       console.log(error);
-      proess.exit(1);
+      process.exit(1);
     }
   });
 });


### PR DESCRIPTION
This fixes #1  where the postinstall script would error out instead of calling process.exit(1)