### PR TITLE
Update selenium-standalone dep to 4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "freeport": "^1.0.4",
     "launchpad": "^0.4.4",
     "lodash": "^3.0.1",
-    "selenium-standalone": "^3.2.0",
+    "selenium-standalone": "^4.2.0",
     "which": "^1.0.8"
   }
 }


### PR DESCRIPTION
* Selenium had issues launching in Firefox 36 but this has been fixed in v2.45[1]
* selenium-standalone v4.2.0 has been released to use v2.45 of selenium

[1] https://code.google.com/p/selenium/issues/detail?id=8399