### PR TITLE
Add new option skipSeleniumInstall to skip the installation process.

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -26,7 +26,8 @@ module.exports = function(wct, pluginOptions) {
   // kick in if someone has specified browsers via another plugin.
   wct.hookLate('configure', function(done) {
     pluginOptions.seleniumPort = pluginOptions.seleniumPort || parseInt(process.env.SELENIUM_PORT);
-
+    pluginOptions.skipSeleniumInstall = pluginOptions.skipSeleniumInstall || false;
+    
     var names = browsers.normalize(pluginOptions.browsers);
     if (names.length > 0) {
       // We support comma separated browser identifiers for convenience.
@@ -71,11 +72,19 @@ module.exports = function(wct, pluginOptions) {
       if (error) return done(error);
       selenium.checkSeleniumEnvironment(function(error) {
         if (error) return done(error);
-        selenium.startSeleniumServer(wct, function(error, port) {
-          if (error) return done(error);
-          updatePort(eachCapabilities, port);
-          done();
-        });
+        if(pluginOptions.skipSeleniumInstall) {
+          selenium.startSeleniumServer(wct, function(error, port) {
+            if (error) return done(error);
+            updatePort(eachCapabilities, port);
+            done();
+          });
+        } else {
+          selenium.installAndStartSeleniumServer(wct, function(error, port) {
+            if (error) return done(error);
+            updatePort(eachCapabilities, port);
+            done();
+          });
+        }
       });
     });
 

--- a/lib/selenium.js
+++ b/lib/selenium.js
@@ -35,7 +35,16 @@ function checkSeleniumEnvironment(done) {
 
 function startSeleniumServer(wct, done) {
   wct.emit('log:info', 'Starting Selenium server for local browsers');
-  checkSeleniumEnvironment(function(error) {
+  checkSeleniumEnvironment(seleniumStart(wct, done, true));
+}
+
+function installAndStartSeleniumServer(wct, done) {
+  wct.emit('log:info', 'Installing and starting Selenium server for local browsers');
+  checkSeleniumEnvironment(seleniumStart(wct, done, false));
+}
+
+function seleniumStart(wct, done, skipinstall) {
+  return function(error) {
     if (error) return done(error);
     freeport(function(error, port) {
       if (error) return done(error);
@@ -63,13 +72,18 @@ function startSeleniumServer(wct, done) {
           server.stderr.on('data', onOutput);
         },
       };
-
-      // Ensure that we have the latest version downloaded.
-      selenium.install({version: '2.47.1', logger: onOutput}, function(error) {
-        if (error) {
-          log.forEach(function(line) { wct.emit('log:info', line) });
-          return done(error);
-        }
+      
+      function install() {
+        selenium.install({version: '2.47.1', logger: onOutput}, function(error) {
+          if (error) {
+            log.forEach(function(line) { wct.emit('log:info', line) });
+            return done(error);
+          }
+          start();
+        });
+      }
+      
+      function start() {
         selenium.start(config, function(error) {
           if (error) {
             log.forEach(function(line) { wct.emit('log:info', line) });
@@ -78,12 +92,19 @@ function startSeleniumServer(wct, done) {
           wct.emit('log:info', 'Selenium server running on port', chalk.yellow(port));
           done(null, port);
         });
-      });
+      }
+      
+      if(skipinstall) {
+        start();
+      } else {
+        install();
+      }
     });
-  });
+  };
 }
 
 module.exports = {
-  checkSeleniumEnvironment: checkSeleniumEnvironment,
-  startSeleniumServer:      startSeleniumServer,
+  checkSeleniumEnvironment:         checkSeleniumEnvironment,
+  startSeleniumServer:              startSeleniumServer,
+  installAndStartSeleniumServer:    installAndStartSeleniumServer
 };


### PR DESCRIPTION
The default will stay as is but the behavior can be overwritten.

This is useful behind a corporate proxy or a when offline.