### PR TITLE
Expose the --skip-selenium-install option.

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,11 @@
       "seleniumPort": {
         "help": "The port of a running selenium server to use.",
         "full": "selenium-port"
+      },
+      "skipSeleniumInstall": {
+        "help": "Skip trying to install selenium.",
+        "full": "skip-selenium-install",
+        "flag": true
       }
     }
   },


### PR DESCRIPTION
(Towards polymer/web-component-tester#215)

This behavior for this option was already built-in to the plugin but there was no way to enable it.