### PR TITLE
Selenium args option

### DIFF
--- a/lib/selenium.js
+++ b/lib/selenium.js
@@ -33,17 +33,19 @@ function checkSeleniumEnvironment(done) {
   });
 }
 
-function startSeleniumServer(wct, done) {
+function startSeleniumServer(wct, args, done) {
   wct.emit('log:info', 'Starting Selenium server for local browsers');
-  checkSeleniumEnvironment(seleniumStart(wct, done, true));
+  var opts = {args: args, install: false};
+  checkSeleniumEnvironment(seleniumStart(wct, opts, done));
 }
 
-function installAndStartSeleniumServer(wct, done) {
+function installAndStartSeleniumServer(wct, args, done) {
   wct.emit('log:info', 'Installing and starting Selenium server for local browsers');
-  checkSeleniumEnvironment(seleniumStart(wct, done, false));
+  var opts = {args: args, install: true};
+  checkSeleniumEnvironment(seleniumStart(wct, opts, done));
 }
 
-function seleniumStart(wct, done, skipinstall) {
+function seleniumStart(wct, opts, done) {
   return function(error) {
     if (error) return done(error);
     freeport(function(error, port) {
@@ -59,7 +61,7 @@ function seleniumStart(wct, done, skipinstall) {
 
       var config = {
         version: '2.47.1',
-        seleniumArgs: ['-port', port],
+        seleniumArgs: ['-port', port].concat(opts.args),
         // Bookkeeping once the process starts.
         spawnCb: function(server) {
           // Make sure that we interrupt the selenium server ASAP.
@@ -94,10 +96,10 @@ function seleniumStart(wct, done, skipinstall) {
         });
       }
       
-      if(skipinstall) {
-        start();
-      } else {
+      if(opts.install) {
         install();
+      } else {
+        start();
       }
     });
   };

--- a/package.json
+++ b/package.json
@@ -27,9 +27,11 @@
         "abbr": "l",
         "list": true
       },
-      "seleniumPort": {
-        "help": "The port of a running selenium server to use.",
-        "full": "selenium-port"
+      "seleniumArgs": {
+	"help": "Additional selenium server arguments. Port is auto-selected.",
+	"full": "selenium-arg",
+	"metavar": "ARG",
+	"list": true
       },
       "skipSeleniumInstall": {
         "help": "Skip trying to install selenium.",


### PR DESCRIPTION
Replaces `--selenium-port` with `--selenium-arg`. The former has never been actually used anyway, so this should be backward-compat.

Occasionally, one need to pass an arbitrary option to the `java -jar selenium.jar`. For instance, in a Docker container:

```
xvfb-run -a wct --skip-plugin sauce --plugin local -l chrome \
  --selenium-arg=-Djava.security.egd=file:///dev/urandom
```