### PR TITLE
Don’t use gulp for building

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,8 +19,7 @@
   "scripts": {
     "lint": "gulp lint",
     "build": "tsc",
-    "test": "gulp test",
-    "prepublish": "gulp build-all",
+    "prepublish": "tsc",
     "postinstall": "node scripts/postinstall.js"
   },
   "wct-plugin": {


### PR DESCRIPTION
This is to let commands like `npm link` work. This project isn't compiling properly with `gulp build`, but I want to get a release out asap.