### PR TITLE
Add support for edge browser if webdriver is available

### DIFF
--- a/custom_typings/wd.d.ts
+++ b/custom_typings/wd.d.ts
@@ -18,7 +18,7 @@ declare module 'wd' {
   }
   export interface Capabilities {
     /** The name of the browser being used */
-    browserName: 'android'|'chrome'|'firefox'|'htmlunit'|'internet explorer'|'iPhone'|'iPad'|'opera'|'safari'|'phantomjs';
+    browserName: 'android'|'chrome'|'firefox'|'htmlunit'|'internet explorer'|'iPhone'|'iPad'|'opera'|'safari'|'phantomjs'|'MicrosoftEdge';
     /** The browser version, or the empty string if unknown. */
     version: string;
     /** A key specifying which platform the browser should be running on. */

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
       },
       "chrome": {},
       "ie": {}
-    }
+    },
+    "javaArgs": ["-Dwebdriver.edge.driver=C:\\Program Files (x86)\\Microsoft Web Driver\\MicrosoftWebDriver.exe"]
   }
 }

--- a/src/browsers.ts
+++ b/src/browsers.ts
@@ -10,9 +10,10 @@
 import * as launchpad from 'launchpad';
 import * as wd from 'wd';
 import * as promisify from 'promisify-node';
+import * as fs from 'fs';
 
 type LaunchpadToWebdriver = (browser: launchpad.Browser) => wd.Capabilities;
-const LAUNCHPAD_TO_SELENIUM: {[browser: string]: LaunchpadToWebdriver} = {
+let LAUNCHPAD_TO_SELENIUM: {[browser: string]: LaunchpadToWebdriver} = {
   chrome:  chrome,
   canary:  chrome,
   firefox: firefox,
@@ -23,6 +24,16 @@ const LAUNCHPAD_TO_SELENIUM: {[browser: string]: LaunchpadToWebdriver} = {
   // See: https://github.com/Polymer/wct-local/issues/38
   // phantom: phantom,
 };
+
+// If webdriver available for edge add it to LAUNCHPAD_TO_SELENIUM.
+const programFiles = process.env['ProgramFiles(x86)'];
+if (programFiles) {
+  const webdriver: string = programFiles + '\\Microsoft Web Driver\\MicrosoftWebDriver.exe';
+  if (fs.existsSync(webdriver)) {
+    const edgeprop = 'edge';
+    LAUNCHPAD_TO_SELENIUM[edgeprop] = edge;
+  }
+}
 
 export function normalize(
       browsers: (string | {browserName: string})[]): string[] {
@@ -172,6 +183,17 @@ function internetExplorer(browser: launchpad.Browser): wd.Capabilities {
   return {
     'browserName': 'internet explorer',
     'version':     browser.version,
+  };
+}
+
+/**
+ * @param browser A launchpad browser definition.
+ * @return A selenium capabilities object.
+ */
+function edge(browser: launchpad.Browser): wd.Capabilities {
+  return {
+    'browserName': 'MicrosoftEdge',
+    'version': browser.version
   };
 }
 


### PR DESCRIPTION
Fix for https://github.com/Polymer/web-component-tester/issues/281

Checks to see if webdriver for edge is available and then adds it to the supported if so.

However, selenium-standalone currently doesn't support installing edge driver automatically https://github.com/vvo/selenium-standalone/issues/147

So it still needs installing manually [here](https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/) and the path passing in (done in the package.json)

Need to ensure the right webdriver version is downloaded for the edge version.