### PR TITLE
update launchpad@^v0.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "chalk": "^1.1.1",
     "cleankill": "^1.0.3",
     "freeport": "^1.0.4",
-    "launchpad": "^0.5.0",
+    "launchpad": "^0.6.0",
     "promisify-node": "^0.4.0",
     "selenium-standalone": "^5.8.0",
     "which": "^1.0.8"

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@types/chalk": "^0.4.28",
     "@types/express": "^4.0.30",
     "@types/freeport": "^1.0.19",
-    "@types/launchpad": "0.0.4",
+    "@types/launchpad": "^0.6.0",
     "@types/node": "^6.0.31",
     "@types/which": "^1.0.27",
     "chalk": "^1.1.1",


### PR DESCRIPTION
- This gets rid of a pesky "uuid" is deprecated message we've seen across our tools during installation.
- Nothing that we use has been affected by the version bump.
- Launchpad changelog here: https://github.com/bitovi/launchpad/compare/0.5.4...v0.6.0
- Creating a DT PR for the change separately

