### PR TITLE
Update Selenium-standalone dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "freeport": "^1.0.4",
     "launchpad": "^0.6.0",
     "promisify-node": "^0.4.0",
-    "selenium-standalone": "^6.4.1",
+    "selenium-standalone": "^6.5.0",
     "which": "^1.0.8"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wct-local",
-  "version": "2.0.15",
+  "version": "2.0.16",
   "description": "WCT plugin that enables support for local browsers via Selenium",
   "keywords": [
     "wct",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "freeport": "^1.0.4",
     "launchpad": "^0.6.0",
     "promisify-node": "^0.4.0",
-    "selenium-standalone": "^5.8.0",
+    "selenium-standalone": "^6.4.1",
     "which": "^1.0.8"
   },
   "engines": {


### PR DESCRIPTION
By updating this dependencies, this will download new chromedriver 2.29, which can be used to run headless