### PR TITLE
Update selenium-standalone to 6.9+

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "freeport": "^1.0.4",
     "launchpad": "^0.6.0",
     "promisify-node": "^0.4.0",
-    "selenium-standalone": "^5.8.0",
+    "selenium-standalone": "^6.9.0",
     "which": "^1.0.8"
   },
   "engines": {


### PR DESCRIPTION
the 5.x version is using an old chrome driver thus breaking on newer os releases.

This does bump the java version to 8.