### PR TITLE
Add browsersOptions to configure Chrome command line options

### DIFF
--- a/src/browsers.ts
+++ b/src/browsers.ts
@@ -84,7 +84,7 @@ export let detect = async function detect(browsersOptions: {}): Promise<{[browse
   for (const browser of browsers) {
     if (!LAUNCHPAD_TO_SELENIUM[browser.name]) continue;
     const converter = LAUNCHPAD_TO_SELENIUM[browser.name];
-    const convertedBrowser = converter(browser, browsersOptions[browser.name]);
+    const convertedBrowser = converter(browser, browsersOptions && browsersOptions[browser.name]);
     if (convertedBrowser) {
       results[browser.name] = convertedBrowser;
     }

--- a/src/browsers.ts
+++ b/src/browsers.ts
@@ -11,7 +11,7 @@ import * as launchpad from 'launchpad';
 import * as wd from 'wd';
 import * as promisify from 'promisify-node';
 
-type LaunchpadToWebdriver = (browser: launchpad.Browser) => wd.Capabilities;
+type LaunchpadToWebdriver = (browser: launchpad.Browser, browsersOptions: {}) => wd.Capabilities;
 const LAUNCHPAD_TO_SELENIUM: {[browser: string]: LaunchpadToWebdriver} = {
   chrome:  chrome,
   canary:  chrome,
@@ -40,7 +40,7 @@ export function normalize(
  *
  * If `names` is empty, or contains `all`, all installed browsers will be used.
  */
-export async function expand(names: string[]): Promise<wd.Capabilities[]> {
+export async function expand(names: string[], browsersOptions: {}): Promise<wd.Capabilities[]> {
   if (names.indexOf('all') !== -1) {
     names = [];
   }
@@ -53,7 +53,7 @@ export async function expand(names: string[]): Promise<wd.Capabilities[]> {
     );
   }
 
-  const installedByName = await detect();
+  const installedByName = await detect(browsersOptions);
   const installed = Object.keys(installedByName);
   // Opting to use everything?
   if (names.length === 0) {
@@ -76,7 +76,7 @@ export async function expand(names: string[]): Promise<wd.Capabilities[]> {
  *
  * Exported and declared as `let` variables for testabilty in wct.
  */
-export let detect = async function detect(): Promise<{[browser: string]: wd.Capabilities}> {
+export let detect = async function detect(browsersOptions: {}): Promise<{[browser: string]: wd.Capabilities}> {
   const launcher = await promisify(launchpad.local)();
   const browsers = await promisify(launcher.browsers)();
 
@@ -84,7 +84,7 @@ export let detect = async function detect(): Promise<{[browser: string]: wd.Capa
   for (const browser of browsers) {
     if (!LAUNCHPAD_TO_SELENIUM[browser.name]) continue;
     const converter = LAUNCHPAD_TO_SELENIUM[browser.name];
-    const convertedBrowser = converter(browser);
+    const convertedBrowser = converter(browser, browsersOptions[browser.name]);
     if (convertedBrowser) {
       results[browser.name] = convertedBrowser;
     }
@@ -110,13 +110,13 @@ export let supported = function supported(): string[] {
  * @param browser A launchpad browser definition.
  * @return A selenium capabilities object.
  */
-function chrome(browser: launchpad.Browser): wd.Capabilities {
+function chrome(browser: launchpad.Browser, browserOptions: string[]): wd.Capabilities {
   return {
     'browserName': 'chrome',
     'version':     browser.version.match(/\d+/)[0],
     'chromeOptions': {
       'binary': browser.binPath,
-      'args': ['start-maximized']
+      'args': browserOptions || ['start-maximized']
     },
   };
 }
@@ -125,7 +125,8 @@ function chrome(browser: launchpad.Browser): wd.Capabilities {
  * @param browser A launchpad browser definition.
  * @return A selenium capabilities object.
  */
-function firefox(browser: launchpad.Browser): wd.Capabilities {
+function firefox(browser: launchpad.Browser, browserOptions: string[])): wd.Capabilities {
+  browserOptions;
   const version = parseInt(browser.version.match(/\d+/)[0], 10);
   const marionette = version >= 47;
   return {
@@ -140,7 +141,8 @@ function firefox(browser: launchpad.Browser): wd.Capabilities {
  * @param browser A launchpad browser definition.
  * @return A selenium capabilities object.
  */
-function safari(browser: launchpad.Browser): wd.Capabilities {
+function safari(browser: launchpad.Browser, browserOptions: string[]): wd.Capabilities {
+  browserOptions;
   // SafariDriver doesn't appear to support custom binary paths. Does Safari?
   return {
     'browserName': 'safari',
@@ -156,7 +158,8 @@ function safari(browser: launchpad.Browser): wd.Capabilities {
  * @param browser A launchpad browser definition.
  * @return A selenium capabilities object.
  */
-function phantom(browser: launchpad.Browser): wd.Capabilities {
+function phantom(browser: launchpad.Browser, browserOptions: string[]): wd.Capabilities {
+  browserOptions;
   return {
     'browserName': 'phantomjs',
     'version':     browser.version,
@@ -168,7 +171,8 @@ function phantom(browser: launchpad.Browser): wd.Capabilities {
  * @param browser A launchpad browser definition.
  * @return A selenium capabilities object.
  */
-function internetExplorer(browser: launchpad.Browser): wd.Capabilities {
+function internetExplorer(browser: launchpad.Browser, browserOptions: string[]): wd.Capabilities {
+  browserOptions;
   return {
     'browserName': 'internet explorer',
     'version':     browser.version,

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -17,6 +17,7 @@ interface PluginOptions {
   seleniumArgs?: string[];
   skipSeleniumInstall?: boolean;
   browsers: string[];
+  browsersOptions?: {};
 }
 
 /** WCT plugin that enables support for local browsers via Selenium. */
@@ -54,11 +55,11 @@ const plugin: wct.PluginInterface = (
 
     // Note that we **do not** append the browsers to `activeBrowsers`
     // until we've got a port chosen for the Selenium server.
-    const expanded = await browsers.expand(names);
+    const expanded = await browsers.expand(names, pluginOptions.browsersOptions);
 
     wct.emit(
         'log:debug',
-        'Expanded local browsers:', names, 'into capabilities:', expanded);
+        'Expanded local browsers:', names, 'into capabilities:', expanded, 'with browsersOptions:', pluginOptions.browsersOptions);
     eachCapabilities = <wct.BrowserDef[]>expanded;
     // We are careful to append these to the configuration object, even though
     // we don't know the selenium port yet. This allows WCT to give a useful


### PR DESCRIPTION
This is copied from

https://github.com/t2ym/wct-headless/commit/ef1a221499a4af76b42492e120ce15557747dfa4

https://github.com/t2ym/wct-headless/commit/b10e23378ea639548ef65f52e9cd50681b8276ab

but is needed to configured no-sandbox for docker.