### PR TITLE
Update wct-local with changes from wct-headless

### DIFF
--- a/custom_typings/wd.d.ts
+++ b/custom_typings/wd.d.ts
@@ -48,6 +48,9 @@ declare module 'wd' {
     };
     firefox_binary?: string;
     marionette?: boolean;
+    'moz:firefoxOptions'?: {
+      args?: string[];
+    },
     'safari.options'?: {
       skipExtensionInstallation?: boolean;
     };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wct-local",
-  "version": "2.0.16",
+  "version": "2.0.17",
   "description": "WCT plugin that enables support for local browsers via Selenium",
   "keywords": [
     "wct",
@@ -48,7 +48,7 @@
     "gulp": "^3.8.10",
     "tools-common": "github:Polymer/tools-common#aa1c22d",
     "tslint": "^3.14.0",
-    "typescript": "^2.0.0"
+    "typescript": "2.3.2"
   },
   "dependencies": {
     "@types/chalk": "^0.4.28",
@@ -62,17 +62,17 @@
     "freeport": "^1.0.4",
     "launchpad": "^0.6.0",
     "promisify-node": "^0.4.0",
-    "selenium-standalone": "^5.8.0",
+    "selenium-standalone": "^6.7.0",
     "which": "^1.0.8"
   },
   "engines": {
     "node": ">=6.0"
   },
   "selenium-overrides": {
-    "version": "3.0.1",
+    "version": "3.4.0",
     "drivers": {
       "firefox": {
-        "version": "0.11.1"
+        "version": "0.18.0"
       },
       "chrome": {},
       "ie": {}

--- a/src/plugin.ts
+++ b/src/plugin.ts
@@ -17,6 +17,7 @@ interface PluginOptions {
   seleniumArgs?: string[];
   skipSeleniumInstall?: boolean;
   browsers: string[];
+  browserOptions?: {};
 }
 
 /** WCT plugin that enables support for local browsers via Selenium. */
@@ -54,11 +55,11 @@ const plugin: wct.PluginInterface = (
 
     // Note that we **do not** append the browsers to `activeBrowsers`
     // until we've got a port chosen for the Selenium server.
-    const expanded = await browsers.expand(names);
+    const expanded = await browsers.expand(names, pluginOptions.browserOptions);
 
     wct.emit(
         'log:debug',
-        'Expanded local browsers:', names, 'into capabilities:', expanded);
+        'Expanded local browsers:', names, 'into capabilities:', expanded, 'with browserOptions:', pluginOptions.browserOptions);
     eachCapabilities = <wct.BrowserDef[]>expanded;
     // We are careful to append these to the configuration object, even though
     // we don't know the selenium port yet. This allows WCT to give a useful


### PR DESCRIPTION
This will fix it so it works with chrome 60+ or chrome versions that has headless installed.