### PR TITLE
Ability to set a different config file to override selenium installation

### DIFF
--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -8,7 +8,9 @@
  * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
  */
 
-var SELENIUM_OVERRIDES = require('../package.json')['selenium-overrides'];
+var seleniumConfig = process.env.SELENIUM_OVERRIDES_CONFIG || '../package.json';
+
+var SELENIUM_OVERRIDES = require(seleniumConfig)['selenium-overrides'];
 // Work around a potential npm race condition:
 // https://github.com/npm/npm/issues/6624
 function requireSelenium(done, attempt) {


### PR DESCRIPTION
This PR provides the ability to define an environment variable with the path of a different configuration file where we intend to define `selenium-overrides`.

More information on #75 